### PR TITLE
feat(get/profile): add API to find profile by user id

### DIFF
--- a/src/main/java/com/linkedin/ProfessionalNetworking/api/profile.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/api/profile.java
@@ -11,7 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -21,6 +23,27 @@ public class profile {
 
     @Autowired
     ProfileService profileService;
+
+    @GetMapping(value = "/profile/{userId}")
+    public ResponseEntity<ApiResponse> getProfileByUserId(@PathVariable String userId) throws JsonParseException {
+        ApiResponse apiResponse = new ApiResponse();
+        if (userId != null) {
+          Profile foundProfile = profileService.getProfileByUserId(userId);
+          if (foundProfile != null) {
+              apiResponse.setResponse(foundProfile);
+              apiResponse.setStatus(HttpStatus.OK.toString());
+              apiResponse.setMessage("Found Profile");
+          } else {
+              apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
+              apiResponse.setMessage("User Id is not exist");
+          }
+        } else {
+          apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
+          apiResponse.setMessage("User Id parameter is missing");
+        }
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
 
     @PostMapping(value = "/profile")
     public ResponseEntity<ApiResponse> createProfile(@RequestBody ProfileRequest profileRequest) throws JsonParseException {

--- a/src/main/java/com/linkedin/ProfessionalNetworking/repository/ProfileRepository.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/repository/ProfileRepository.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
-    public List<Profile> findByUserId(String userId);
+    public Profile findByUserId(String userId);
 }

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/ProfileService.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/ProfileService.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface ProfileService {
 
+    Profile getProfileByUserId(String userId);
     List<Profile> createProfileForUser(ProfileRequest profileRequest);
 }

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ProfileServiceImpl.java
@@ -16,6 +16,11 @@ public class ProfileServiceImpl implements ProfileService {
     ProfileRepository profileRepository;
 
     @Override
+    public Profile getProfileByUserId(String userId) {
+        return profileRepository.findByUserId(userId);
+    }
+
+    @Override
     public List<Profile> createProfileForUser(ProfileRequest profileRequest) {
         Profile profilePayload = new Profile();
         profilePayload.setUserId(profileRequest.getUserId());


### PR DESCRIPTION
## Issue ID
NA

## Summary
Able to find profile by user id

## Steps to implement this feature
1. Add GetMapping controller method
2. Add New JPA Method to find by user id
3. Add New Service Interface to find by user id
4. Update Service Imp to find by user id

## Checklist

- [x] Have you added the summary of what your changes do and why you'd like us to include them?
- [x] Have you added the steps to implement this feature?
- [ ] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the need for this tech update, and the steps to reproduce the issue?
No API to find a profile

### What is the current status?
Added API to find a profile by user id.

### How does this PR fix the problem, Screenshot Please?
#### Found Profile
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/1652629/164263098-4657f3b9-759b-4201-8e63-b26e3337c603.png">

#### Profile is not exist
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/1652629/164263177-88a10324-7484-4d77-80fe-2787c3491e33.png">
