### PR TITLE
feat(put/profile): update Profile API by profile id

### DIFF
--- a/src/main/java/com/linkedin/ProfessionalNetworking/api/profile.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/api/profile.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -53,6 +54,21 @@ public class profile {
             apiResponse.setResponse(newProfile);
             apiResponse.setStatus(HttpStatus.OK.toString());
             apiResponse.setMessage("New Profile Created");
+        } else {
+            apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
+            apiResponse.setMessage(Constants.EMPTY_USER_REQUEST);
+        }
+        return ResponseEntity.ok().body(apiResponse);
+    }
+
+    @PutMapping(value = "/profile")
+    public ResponseEntity<ApiResponse> updateProfile(@RequestBody ProfileRequest profileRequest) throws JsonParseException {
+        ApiResponse apiResponse = new ApiResponse();
+        if(profileRequest != null) {
+            Profile profileToBeUpdated = profileService.updateProfileByProfileId(profileRequest);
+            apiResponse.setResponse(profileToBeUpdated);
+            apiResponse.setStatus(HttpStatus.OK.toString());
+            apiResponse.setMessage("Profile Updated");
         } else {
             apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
             apiResponse.setMessage(Constants.EMPTY_USER_REQUEST);

--- a/src/main/java/com/linkedin/ProfessionalNetworking/dto/ProfileRequest.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/dto/ProfileRequest.java
@@ -12,4 +12,6 @@ public class ProfileRequest {
     public String additionalName;
 
     public String userId;
+
+    public Long profileId;
 }

--- a/src/main/java/com/linkedin/ProfessionalNetworking/repository/ProfileRepository.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/repository/ProfileRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 public interface ProfileRepository extends JpaRepository<Profile, Long> {
 
     public Profile findByUserId(String userId);
+    public Profile findByProfileId(String profileId);
 }

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/ProfileService.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/ProfileService.java
@@ -8,5 +8,6 @@ import java.util.List;
 public interface ProfileService {
 
     Profile getProfileByUserId(String userId);
+    Profile updateProfileByProfileId(ProfileRequest profileRequest);
     List<Profile> createProfileForUser(ProfileRequest profileRequest);
 }

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ProfileServiceImpl.java
@@ -21,6 +21,18 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
+    public Profile updateProfileByProfileId(ProfileRequest profileRequest) {
+        Profile profilePayload = new Profile();
+        profilePayload.setUserId(profileRequest.getUserId());
+        profilePayload.setFirstName(profileRequest.getFirstName());
+        profilePayload.setProfileId(profileRequest.getProfileId());
+        profilePayload.setLastName(profileRequest.getLastName());
+        profilePayload.setAdditionalName(profileRequest.getAdditionalName());
+        profileRepository.save(profilePayload);
+        return null;
+    }
+
+    @Override
     public List<Profile> createProfileForUser(ProfileRequest profileRequest) {
         Profile profilePayload = new Profile();
         profilePayload.setUserId(profileRequest.getUserId());

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ProfileServiceImpl.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ProfileServiceImpl.java
@@ -21,15 +21,15 @@ public class ProfileServiceImpl implements ProfileService {
     }
 
     @Override
-    public Profile updateProfileByProfileId(ProfileRequest profileRequest) {
-        Profile profilePayload = new Profile();
-        profilePayload.setUserId(profileRequest.getUserId());
-        profilePayload.setFirstName(profileRequest.getFirstName());
-        profilePayload.setProfileId(profileRequest.getProfileId());
-        profilePayload.setLastName(profileRequest.getLastName());
-        profilePayload.setAdditionalName(profileRequest.getAdditionalName());
-        profileRepository.save(profilePayload);
-        return null;
+    public Profile updateProfileByProfileId(ProfileRequest updateProfilePayload) {
+        Profile updatedProfile = new Profile();
+        updatedProfile.setUserId(updateProfilePayload.getUserId());
+        updatedProfile.setFirstName(updateProfilePayload.getFirstName());
+        updatedProfile.setProfileId(updateProfilePayload.getProfileId());
+        updatedProfile.setLastName(updateProfilePayload.getLastName());
+        updatedProfile.setAdditionalName(updateProfilePayload.getAdditionalName());
+        profileRepository.save(updatedProfile);
+        return updatedProfile;
     }
 
     @Override


### PR DESCRIPTION
## Issue ID
NA

## Summary
Able to update profile by profile id

## Steps to implement this feature
1. Add PutMapping controller method
2. Add New JPA Method to find by user id
3. Add New Service Interface to find by user id
4. Update Service Imp to find by user id

## Checklist

- [x] Have you added the summary of what your changes do and why you'd like us to include them?
- [x] Have you added the steps to implement this feature?
- [ ] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the need for this tech update, and the steps to reproduce the issue?
No API to update a profile

### What is the current status?
Added API to update profile by profile id.

### How does this PR fix the problem, Screenshot Please?
#### Change Additional Name
<img width="1084" alt="image" src="https://user-images.githubusercontent.com/1652629/164286767-adc35b55-aad0-43dc-9005-1f7d02ca4ef9.png">

#### DB Query after changes
<img width="685" alt="image" src="https://user-images.githubusercontent.com/1652629/164286978-4d19e030-edf6-40c1-9ffb-01a6a94774c8.png">
