### PR TITLE
feat(get/experience): add API to find all experience by user id

### DIFF
--- a/src/main/java/com/linkedin/ProfessionalNetworking/api/experience.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/api/experience.java
@@ -11,7 +11,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
@@ -21,6 +23,27 @@ public class experience {
 
     @Autowired
     ExperienceService experienceService;
+
+    @GetMapping(value = "/experience/{userId}")
+    public ResponseEntity<ApiResponse> getExperienceByUserId(@PathVariable String userId) {
+        ApiResponse apiResponse = new ApiResponse();
+        if (userId != null) {
+            List<Experience> foundExperience = experienceService.getExperienceByUserId(userId);
+            if (foundExperience != null) {
+                apiResponse.setResponse(foundExperience);
+                apiResponse.setStatus(HttpStatus.OK.toString());
+                apiResponse.setMessage("Found Experience");
+            } else {
+                apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
+                apiResponse.setMessage(Constants.USER_ID_NOT_EXIST);
+            }
+        } else {
+            apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
+            apiResponse.setMessage(Constants.EMPTY_USER_REQUEST);
+        }
+
+        return ResponseEntity.ok().body(apiResponse);
+    }
 
     @PostMapping(value = "/experience")
     public ResponseEntity<ApiResponse> createExperience(@RequestBody ExperienceRequest experienceRequest) throws JsonProcessingException {

--- a/src/main/java/com/linkedin/ProfessionalNetworking/api/profile.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/api/profile.java
@@ -36,11 +36,11 @@ public class profile {
               apiResponse.setMessage("Found Profile");
           } else {
               apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
-              apiResponse.setMessage("User Id is not exist");
+              apiResponse.setMessage(Constants.USER_ID_NOT_EXIST);
           }
         } else {
           apiResponse.setStatus(HttpStatus.BAD_REQUEST.toString());
-          apiResponse.setMessage("User Id parameter is missing");
+            apiResponse.setMessage(Constants.EMPTY_USER_REQUEST);
         }
 
         return ResponseEntity.ok().body(apiResponse);

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/ExperienceService.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/ExperienceService.java
@@ -7,5 +7,6 @@ import java.util.List;
 
 public interface ExperienceService {
 
+    List<Experience> getExperienceByUserId(String userId);
     List<Experience> createExperience(ExperienceRequest experienceRequest);
 }

--- a/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ExperienceServiceImpl.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/service/impl/ExperienceServiceImpl.java
@@ -16,6 +16,11 @@ public class ExperienceServiceImpl implements ExperienceService {
     ExperienceRepository experienceRepository;
 
     @Override
+    public List<Experience> getExperienceByUserId(String userId) {
+        return experienceRepository.findByUserId(userId);
+    }
+
+    @Override
     public List<Experience> createExperience(ExperienceRequest experienceRequest) {
         Experience experiencePayload = new Experience();
         experiencePayload.setUserId(experienceRequest.getUserId());

--- a/src/main/java/com/linkedin/ProfessionalNetworking/util/Constants.java
+++ b/src/main/java/com/linkedin/ProfessionalNetworking/util/Constants.java
@@ -4,9 +4,10 @@ public final class Constants {
 
     public static final String INVALID_USERNAME_PASSWORD = "Invalid UserName and Password";
 
-    public static final String EMPTY_USER_REQUEST = "Invalid User Id";
+    public static final String EMPTY_USER_REQUEST = "User Id parameter is empty / missing";
 
+    public static final String USER_ID_NOT_EXIST = "User Id is not exist";
 
-
+    public static final String USER_ID_PARAMETER_MISSING = "User Id parameter is missing";
 
 }


### PR DESCRIPTION
## Issue ID
NA

## Summary
Able to find experience by user id

## Steps to implement this feature
1. Add GetMapping controller method
2. Add New JPA Method to find by user id
3. Add New Service Interface to find by user id
4. Update Service Imp to find by user id

## Checklist

- [x] Have you added the summary of what your changes do and why you'd like us to include them?
- [x] Have you added the steps to implement this feature?
- [ ] Have the files been linted and formatted?
- [ ] Have the docs been updated to match the changes in the PR?
- [ ] Have the tests been updated to match the changes in the PR?
- [ ] Have you run the tests locally to confirm they pass?

### What is the need for this tech update, and the steps to reproduce the issue?
No API to find a experience

### What is the current status?
Added API to find a experience by user id.

### How does this PR fix the problem, Screenshot Please?

#### Found Experience

<img width="1187" alt="image" src="https://user-images.githubusercontent.com/1652629/164351791-d7e49096-ee96-4137-afb4-9d895f9250c7.png">

<img width="1097" alt="image" src="https://user-images.githubusercontent.com/1652629/164351826-b280e986-1c37-4778-a16d-6e02cd28741d.png">

#### Experience is not exist

<img width="1158" alt="image" src="https://user-images.githubusercontent.com/1652629/164351872-c8c6be3e-bb35-497f-8444-7a75456a208b.png">

